### PR TITLE
Remove misleading instuction

### DIFF
--- a/eth-contracts/contracts/ERC721Mintable.sol
+++ b/eth-contracts/contracts/ERC721Mintable.sol
@@ -456,7 +456,7 @@ contract ERC721Metadata is ERC721Enumerable, usingOraclize {
 //      - make the base token uri: https://s3-us-west-2.amazonaws.com/udacity-blockchain/capstone/
 //  2) create a public mint() that does the following:
 //      -can only be executed by the contract owner
-//      -takes in a 'to' address, tokenId, and tokenURI as parameters
+//      -takes in a 'to' address and tokenId as parameters
 //      -returns a true boolean upon completion of the function
 //      -calls the superclass mint and setTokenURI functions
 


### PR DESCRIPTION
tokenURI should not be needed and could confuse students, tokenURI is already defined in the contract before ERC721Metadata